### PR TITLE
Update eventType domain in schema

### DIFF
--- a/data-product/README.md
+++ b/data-product/README.md
@@ -33,7 +33,7 @@ The **Paymentic Wallet Transactions** data product provides real-time analytical
 - **Source System**: Paymentic Wallet Application
 - **Event Stream**: Kafka topic `merchant-account`
 - **Event Format**: CloudEvents JSON
-- **Event Type**: `funny-bunny.xyz.merchant-account.v1.transaction.registered`
+- **Event Type**: `paymentic.com.merchant-account.v1.transaction.registered`
 - **Data Freshness**: < 30 seconds
 - **Availability SLA**: 99.9%
 
@@ -53,7 +53,7 @@ The **Paymentic Wallet Transactions** data product provides real-time analytical
 | `checkoutId` | STRING | Checkout session identifier (null for refunds) | "checkout123" | Yes |
 | `eventSource` | STRING | CloudEvent source identifier | "/transactions/123e4567-e89b-12d3-a456-426614174000" | No |
 | `eventSubject` | STRING | CloudEvent subject | "payment-created" | No |
-| `eventType` | STRING | CloudEvent type | "funny-bunny.xyz.merchant-account.v1.transaction.registered" | No |
+| `eventType` | STRING | CloudEvent type | "paymentic.com.merchant-account.v1.transaction.registered" | No |
 | `cloudEventId` | STRING | CloudEvent unique identifier | "ce-123e4567-e89b-12d3-a456-426614174000" | No |
 
 ### Metric Fields (Aggregation)


### PR DESCRIPTION
Replace placeholder domain 'funny-bunny.xyz' with 'paymentic.com' in README.md.

The `eventType` field in the schema definition contained an accidentally committed test/placeholder domain, which could lead to configuration issues.